### PR TITLE
syntax correction on folders prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ grunt.initConfig({
             src:    '<%= multisync.options.drives.MyHardDrive %>',
             dest:   '<%= multisync.options.drives.MyBackupDrive %>'
         },
-        folders: {
+        folders: [
             {src: '/TestFolder/', dest: '/test-folder', recursive: false},
             {src: '/TestFolder2/', dest: '/TestFolder2'},
             {src: '/NamesDontHave/', dest: '/_to_be__the_same_'},
-        },
+        ],
         options: {
             // any rsyncwrapper options here get allpied to ALL folder pairs
             recursive: true,


### PR DESCRIPTION
hey, thanks for this plugin...I'm new to grunt, and at first wasn't sure if the keys for each object in 'folders' were missing, or if folders should actually be an array.  Hopefully this will help new grunt users who are relying on the examples here.